### PR TITLE
Advanced anvil changes

### DIFF
--- a/src/main/java/io/github/mooy1/infinityexpansion/items/blocks/AdvancedAnvil.java
+++ b/src/main/java/io/github/mooy1/infinityexpansion/items/blocks/AdvancedAnvil.java
@@ -107,10 +107,22 @@ public final class AdvancedAnvil extends AbstractEnergyCrafter {
         }
 
         ItemStack item1 = inv.getItemInSlot(INPUT_SLOTS[0]);
+        SlimefunItem sfItem1 = SlimefunItem.getByItem(inv.getItemInSlot(INPUT_SLOTS[0]));
         ItemStack item2 = inv.getItemInSlot(INPUT_SLOTS[1]);
+        SlimefunItem sfItem2 = SlimefunItem.getByItem(inv.getItemInSlot(INPUT_SLOTS[1]));
 
         if (item1 == null || item2 == null || (item2.getType() != Material.ENCHANTED_BOOK && item1.getType() != item2.getType())) {
             p.sendMessage(ChatColor.RED + "Invalid items!");
+            return;
+        }
+        
+        if(sfItem2 != null && !sfItem2.isDisenchantable()) {
+            p.sendMessage(ChatColor.RED + "Slimefun item is not disenchantable!");
+            return;
+        }
+
+        if(sfItem1 != null && !sfItem1.isEnchantable()) {
+            p.sendMessage(ChatColor.RED + "Slimefun item is not enchantable!");
             return;
         }
 

--- a/src/main/java/io/github/mooy1/infinityexpansion/items/blocks/AdvancedAnvil.java
+++ b/src/main/java/io/github/mooy1/infinityexpansion/items/blocks/AdvancedAnvil.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -115,13 +116,13 @@ public final class AdvancedAnvil extends AbstractEnergyCrafter {
             p.sendMessage(ChatColor.RED + "Invalid items!");
             return;
         }
-        
-        if(sfItem2 != null && !sfItem2.isDisenchantable()) {
+
+        if(sfItem2 != null && !sfItem2.isDisenchantable()){
             p.sendMessage(ChatColor.RED + "Slimefun item is not disenchantable!");
             return;
         }
 
-        if(sfItem1 != null && !sfItem1.isEnchantable()) {
+        if(sfItem1 != null && !sfItem1.isEnchantable()){
             p.sendMessage(ChatColor.RED + "Slimefun item is not enchantable!");
             return;
         }


### PR DESCRIPTION
Prevents slimefun items from being disenchanted or enchanted when the settings (overriden) for that slimefun item is not allowed to.