### PR TITLE
Fixes PoweredBedrock energy use and powered state

### DIFF
--- a/src/main/java/io/github/mooy1/infinityexpansion/items/machines/PoweredBedrock.java
+++ b/src/main/java/io/github/mooy1/infinityexpansion/items/machines/PoweredBedrock.java
@@ -45,6 +45,7 @@ public final class PoweredBedrock extends SlimefunItem implements EnergyNetCompo
                 if (getCharge(l) < energy) {
                     if (b.getType() != Material.NETHERITE_BLOCK) {
                         b.setType(Material.NETHERITE_BLOCK);
+                        return;
                     }
                 }
                 else if (b.getType() != Material.BEDROCK) {

--- a/src/main/java/io/github/mooy1/infinityexpansion/items/machines/PoweredBedrock.java
+++ b/src/main/java/io/github/mooy1/infinityexpansion/items/machines/PoweredBedrock.java
@@ -49,8 +49,8 @@ public final class PoweredBedrock extends SlimefunItem implements EnergyNetCompo
                 }
                 else if (b.getType() != Material.BEDROCK) {
                     b.setType(Material.BEDROCK);
-                    removeCharge(l, energy);
                 }
+                removeCharge(l, energy);
             }
         });
     }


### PR DESCRIPTION
Fixes #99 

Powered bedrock only takes power when changing type to bedrock, lore clearly states a constant power drain when in it's powered state. This also ensures the block will revert to it's unpowered state when unpowered after a few ticks.