### PR TITLE
changed night generation type to darkness

### DIFF
--- a/src/main/java/io/github/mooy1/infinityexpansion/items/generators/GenerationType.java
+++ b/src/main/java/io/github/mooy1/infinityexpansion/items/generators/GenerationType.java
@@ -43,7 +43,7 @@ public enum GenerationType {
             return 0;
         }
     },
-    LUNAR("Night") {
+    LUNAR("Darkness") {
         @Override
         protected int generate(@Nonnull World world, @Nonnull Block block, int def) {
             switch (world.getEnvironment()) {


### PR DESCRIPTION
the energy type night produces energy as long as the light level from the sky is below 15 which can happen anytime of day and not just night and its use is the void panel and that items description is generates energy from darkness and therefore as it doesn't actually relate to night i think its more apt to call it darkness instead of night