### PR TITLE
Fix Recipe for Zombie Data Card

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Some stats about the addon including current server count and player count are a
 https://bstats.org/plugin/bukkit/InfinityExpansion/8991
 
 ## Changelog
+### Version 141
+- Fix Zombie Data Card Recipe using 1 iron ingot instead of 64.
 ### Version 140
 - Fix Powered Bedrock not taking the correct charge and getting stuck in a powered state
 ### Version 123

--- a/src/main/java/io/github/mooy1/infinityexpansion/items/mobdata/MobData.java
+++ b/src/main/java/io/github/mooy1/infinityexpansion/items/mobdata/MobData.java
@@ -99,7 +99,7 @@ public final class MobData {
 
         new MobDataCard(ZOMBIE, MobDataTier.HOSTILE, new ItemStack[] {
                 new ItemStack(Material.IRON_SWORD, 1), new ItemStack(Material.ROTTEN_FLESH, 16), new ItemStack(Material.IRON_SHOVEL, 1),
-                new ItemStack(Material.IRON_INGOT, 64), EMPTY_DATA_CARD, new ItemStack(Material.IRON_INGOT, 1),
+                new ItemStack(Material.IRON_INGOT, 64), EMPTY_DATA_CARD, new ItemStack(Material.IRON_INGOT, 64),
                 new ItemStack(Material.CARROT, 64), new ItemStack(Material.ROTTEN_FLESH, 16), new ItemStack(Material.POTATO, 64)
         }).addDrop(Material.ROTTEN_FLESH, 1).register(plugin);
         new MobDataCard(SLIME, MobDataTier.NEUTRAL, new ItemStack[] {


### PR DESCRIPTION
Simply changes the Zombie Data Cards Recipe to have 64 Iron ingots on both sides instead of just 1