### PR TITLE
Use Slimefun RC-34

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.github.Slimefun</groupId>
             <artifactId>Slimefun4</artifactId>
-            <version>5dbe617205</version>
+            <version>RC-34</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
Fixed the build failure introduced by PR #109, the build artifact of Slimefun that IE is using no longer exists.