### PR TITLE
dupe PoweredBedrock prevention

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.github.Slimefun</groupId>
             <artifactId>Slimefun4</artifactId>
-            <version>934ab822a6</version>
+            <version>RC-37</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/io/github/mooy1/infinityexpansion/items/machines/PoweredBedrock.java
+++ b/src/main/java/io/github/mooy1/infinityexpansion/items/machines/PoweredBedrock.java
@@ -43,6 +43,12 @@ public final class PoweredBedrock extends SlimefunItem implements EnergyNetCompo
                 }
                 Location l = b.getLocation();
                 if (getCharge(l) < energy) {
+
+                    // dupe prevention 
+                    if (b.getType() == Material.AIR) {
+                        return;
+                    }
+                    
                     if (b.getType() != Material.NETHERITE_BLOCK) {
                         b.setType(Material.NETHERITE_BLOCK);
                         return;


### PR DESCRIPTION
I think the better way, is verify if the block is a BEDROCK, if so, change to NETHERITE. But this can break another things if not use netherite block